### PR TITLE
Take care for PGDATABASE environment variable and get rid of default dat...

### DIFF
--- a/pgstat.c
+++ b/pgstat.c
@@ -479,7 +479,15 @@ get_opts(int argc, char **argv)
 
 	if (opts->dbname == NULL)
 	{
-		opts->dbname = "postgres";
+		/*
+		 * We want to use dbname for possible error reports later,
+		 * and in case someone has set and is using PGDATABASE
+		 * in its environment preserve that name for later usage
+		 */
+		if (!getenv("PGDATABASE"))
+			opts->dbname = "postgres";
+		else
+			opts->dbname = getenv("PGDATABASE");
 	}
 }
 


### PR DESCRIPTION
...abase 'postgres'.

PQsetdbLogin() would use PGDATABASE in case dbname is not specified
on the command line. However, since dbname is used in the error message,
we need to take care for it.