### PR TITLE
Make Makefile more compatible with PGXS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ PROGRAMS = pgcsvstat pgstat pgdisplay pgwaitevent pgreport
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)
+SCRIPTS_built = pgcsvstat pgstat pgdisplay pgwaitevent pgreport
+EXTRA_CLEAN = rm -f $(addsuffix $(X), $(PROGRAMS)) $(addsuffix .o, $(PROGRAMS))
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
@@ -21,5 +23,3 @@ pgstat: pgstat.o
 pgwaitevent: pgwaitevent.o
 pgreport: pgreport.o
 
-clean:
-	rm -f $(addsuffix $(X), $(PROGRAMS)) $(addsuffix .o, $(PROGRAMS))


### PR DESCRIPTION
Looks like current Makefile does not correctly install compiled binaries
into $PGSQL_HOME/bin, rendering "make install" into a no-op, not installing
anything.

Since PGXS doesn't allow to specify multiple binaries in PROGRAM reliably, use the
SCRIPTS_built makro and EXTRA_CLEAN to tell PGXS to do the right thing.
This doesn't require our own "clean" target anymore, since the PGXS
machinery does the work for us now, including "uninstall".