### PR TITLE
message emptyed by PQfinish before errx(..., message)

### DIFF
--- a/pgstat.c
+++ b/pgstat.c
@@ -861,8 +861,8 @@ sql_conn()
 	if (PQstatus(my_conn) == CONNECTION_BAD)
 	{
 		message = PQerrorMessage(my_conn);
-		PQfinish(my_conn);
 		errx(1, "could not connect to database %s: %s", opts->dbname, message);
+		PQfinish(my_conn);
 	}
 
 	/* return the conn if good */


### PR DESCRIPTION
errx(1, "could not connect to database %s: %s", opts->dbname, message) 

can't display 'message' if PGFinish(my_conn) is called before.

./pgstat -d plo 1
pgstat: pgstat@865: could not connect to database plo: �_6�U

 ./pgstat -d plo 1
pgstat: pgstat@865: could not connect to database plo: FATAL:  database "plo" does not exist