### PR TITLE
Makefile: add pkglibdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: $(PROGRAMS)
 
 pgreport.o: pgreport_queries.h
 %: %.o $(WIN32RES)
-	   $(CC) $(CFLAGS) $^ $(libpq_pgport) $(LDFLAGS) -lpgfeutils -lpgcommon -lpgport -lm -o $@$(X)
+	   $(CC) $(CFLAGS) $^ $(libpq_pgport) $(LDFLAGS) -L $(pkglibdir)  -lpgfeutils -lpgcommon -lpgport -lm -o $@$(X)
 
 pgcsvstat: pgcsvstat.o
 pgdisplay: pgdisplay.o


### PR DESCRIPTION
Add a reference to `$(pkglibdir)` in the `Makefile`.
For some reason, `make` was unable to find `/usr/lib/postgresql/17/lib` on its own without this.

Tested on Debian 12/PG17. 
Could not test on Rocky9, in part because of #24